### PR TITLE
fixed navigation bug that keeps redrawing after log out and log in pa…

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -128,7 +128,11 @@ class _DashboardPageState extends State<DashboardPage> {
       actions: <Widget>[
         IconButton(
           icon: Icon(Icons.power_settings_new),
-          onPressed: () { AccessService.logOut(); return;},
+          onPressed: () { 
+            AccessService.logOut();
+            Navigator.of(context).pushReplacementNamed('auth');
+            return;
+          },
           iconSize: 30,
         ),
       ],

--- a/lib/services/access_service.dart
+++ b/lib/services/access_service.dart
@@ -47,7 +47,6 @@ class AccessService {
   static void logOut() async {
     await LocalStorage.removeItem(AccessService._key);
     AccessService.clearCache();
-    AccessService._navigationService.navigateTo(routes.Auth);
     return;
   }
 
@@ -160,18 +159,3 @@ class AccessService {
     return numberOfUnread;
   }
 }
-/*
-  static numberOfUnreadMessages(states) {
-    let arrayOfStates = states.split(Helper.seperator);
-    let unread = 0;
-    let userId = (new AppAccess()).userId;
-    for (let i = 0; i < arrayOfStates.length; i++) {
-      let splitEachState = arrayOfStates[i].split(',');
-      if (splitEachState[0].toString() === userId.toString()) {
-        if (splitEachState[1] === '0') {
-          unread += 1;
-        }
-      }
-    }
-    return unread;
-  }*/


### PR DESCRIPTION
Fixed bug with navigation. login page keeps redrawing when log out button button is pushed from the dashboard and the login page is pushed to the navigation stack with Navigator.of(context).pushNamed. Call to Navigator.of(context).pushReplacementNamed solved the problem.